### PR TITLE
Make frame blocks capable of conducting (connecting) to RS networks

### DIFF
--- a/src/main/java/RebornStorage/tiles/TileMultiCrafter.java
+++ b/src/main/java/RebornStorage/tiles/TileMultiCrafter.java
@@ -178,7 +178,8 @@ public class TileMultiCrafter extends RectangularMultiblockTileEntityBase implem
 
 	@Override
 	public boolean canConduct(EnumFacing enumFacing) {
-		return false;
+		// Only frame blocks can conduct (e.g. connect to network)
+		return getBlockMetadata() == 0;
 	}
 
 	@Override


### PR DESCRIPTION
Hey guys,

This PR will make it so that the frame blocks of the crafting frame can conduct the RS network.  This serves two purposes:

1) RS cables (and cables/conduits from other mods and addons) will know that the frame blocks support connection and can use that information to visually show that connection.  There is a PR going into the 1.10 RS that will use canConduct to decide if cables should visually connect to blocks.  Functional connection to the network will not be affected since the canConduct check for building the network is only processed in one direction, moving away from the RS controller.

2) The frame can be used to carry on the RS network.  Because crafting frame blocks are set not to conduct, the structure is the endpoint of the functional network.  If the frame blocks had canConduct=true the network could continue on past the frame.  As it is, additional cables will visually connect to a crafting frame but they and anything attached to them will not be on the functional RS network.  This PR will bring the visual and functional networks into sync.

Thanks, and thanks for bringing back the multiblock crafter!