### PR TITLE
Prevent ClassCastException

### DIFF
--- a/src/main/java/me/modmuss50/rebornstorage/tiles/TileMultiCrafter.java
+++ b/src/main/java/me/modmuss50/rebornstorage/tiles/TileMultiCrafter.java
@@ -1,5 +1,6 @@
 package me.modmuss50.rebornstorage.tiles;
 
+import com.raoulvdberge.refinedstorage.api.network.node.INetworkNode;
 import com.raoulvdberge.refinedstorage.api.network.node.INetworkNodeManager;
 import com.raoulvdberge.refinedstorage.api.network.node.INetworkNodeProxy;
 import com.raoulvdberge.refinedstorage.apiimpl.API;
@@ -200,7 +201,14 @@ public class TileMultiCrafter extends RectangularMultiblockTileEntityBase implem
 			return clientNode;
 		}
 		INetworkNodeManager manager = API.instance().getNetworkNodeManager(this.world);
-		CraftingNode node = (CraftingNode) manager.getNode(this.pos);
+		INetworkNode rawNode = manager.getNode(this.pos);
+		if (rawNode == null || !(rawNode instanceof CraftingNode)) {
+			if (clientNode == null) {
+				clientNode = new CraftingNode(world, getPos());
+			}
+			return clientNode;
+		}
+		CraftingNode node = (CraftingNode) rawNode;
 		if (node == null || !node.getId().equals(RebornStorage.MULTI_BLOCK_ID)) {
 			manager.setNode(this.pos, node = new CraftingNode(world, getPos()));
 			manager.markForSaving();

--- a/src/main/java/me/modmuss50/rebornstorage/tiles/TileMultiCrafter.java
+++ b/src/main/java/me/modmuss50/rebornstorage/tiles/TileMultiCrafter.java
@@ -201,20 +201,13 @@ public class TileMultiCrafter extends RectangularMultiblockTileEntityBase implem
 			return clientNode;
 		}
 		INetworkNodeManager manager = API.instance().getNetworkNodeManager(this.world);
-		INetworkNode rawNode = manager.getNode(this.pos);
-		if (rawNode == null || !(rawNode instanceof CraftingNode)) {
-			if (clientNode == null) {
-				clientNode = new CraftingNode(world, getPos());
-			}
-			return clientNode;
-		}
-		CraftingNode node = (CraftingNode) rawNode;
+		INetworkNode node = manager.getNode(this.pos);
 		if (node == null || !node.getId().equals(RebornStorage.MULTI_BLOCK_ID)) {
 			manager.setNode(this.pos, node = new CraftingNode(world, getPos()));
 			manager.markForSaving();
 		}
 
-		return node;
+		return (CraftingNode) node;
 	}
 
 	@Override


### PR DESCRIPTION
When INetworkNode is of class ConduitRefinedStorageNode we get a server crash with report like:

```
java.lang.ClassCastException: crazypants.enderio.conduits.refinedstorage.conduit.ConduitRefinedStorageNode cannot be cast to me.modmuss50.rebornstorage.tiles.CraftingNode
	at me.modmuss50.rebornstorage.tiles.TileMultiCrafter.getNode(TileMultiCrafter.java:203)
	at me.modmuss50.rebornstorage.tiles.TileMultiCrafter.getNode(TileMultiCrafter.java:32)
	at com.raoulvdberge.refinedstorage.apiimpl.network.NetworkNodeGraph$Operator.apply(NetworkNodeGraph.java:143)
	at crazypants.enderio.conduits.refinedstorage.conduit.ConduitRefinedStorageNode.visit(ConduitRefinedStorageNode.java:117)
	at com.raoulvdberge.refinedstorage.apiimpl.network.NetworkNodeGraph$Visitor.visit(NetworkNodeGraph.java:180)
	at com.raoulvdberge.refinedstorage.apiimpl.network.NetworkNodeGraph.rebuild(NetworkNodeGraph.java:59)
	at crazypants.enderio.conduits.refinedstorage.conduit.ConduitRefinedStorageNode.onConduitConnectionChange(ConduitRefinedStorageNode.java:124)
	at crazypants.enderio.conduits.refinedstorage.conduit.RefinedStorageConduit.connectionsChanged(RefinedStorageConduit.java:233)
	at crazypants.enderio.conduits.conduit.AbstractConduit.updateConnections(AbstractConduit.java:416)
	at crazypants.enderio.conduits.conduit.AbstractConduit.updateEntity(AbstractConduit.java:382)
	at crazypants.enderio.conduits.conduit.TileConduitBundle.doUpdate(TileConduitBundle.java:336)
	at com.enderio.core.common.TileEntityBase.func_73660_a(TileEntityBase.java:47)
	at net.minecraft.world.World.func_72939_s(World.java:1832)
	at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:613)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:767)
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:396)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
	at java.lang.Thread.run(Thread.java:748)
```

The related code is line 203 of TileMultiCrafter where an explicit cast to CraftingNode is present. I have prefixed that cast with an instanceof test which should only allow the cast to occur when the INetworkNode is of type CraftingNode.