### PR TITLE
add tags for disks/parts and use them in recipes

### DIFF
--- a/src/main/resources/data/rebornstorage/recipes/disks/large_fluid_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/large_fluid_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:large_fluid_disk_part"
+        "tag": "refinedstorage:parts/fluids/4096k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/disks/large_item_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/large_item_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:large_item_disk_part"
+        "tag": "refinedstorage:parts/items/4096k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/disks/larger_fluid_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/larger_fluid_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:larger_fluid_disk_part"
+        "tag": "refinedstorage:parts/fluids/16384k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/disks/larger_item_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/larger_item_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:larger_item_disk_part"
+        "tag": "refinedstorage:parts/items/16384k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/disks/medium_fluid_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/medium_fluid_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:medium_fluid_disk_part"
+        "tag": "refinedstorage:parts/fluids/1024k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/disks/medium_item_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/medium_item_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:medium_item_disk_part"
+        "tag": "refinedstorage:parts/items/1024k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/disks/small_fluid_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/small_fluid_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:small_fluid_disk_part"
+        "tag": "refinedstorage:parts/fluids/256k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/disks/small_item_disk.json
+++ b/src/main/resources/data/rebornstorage/recipes/disks/small_item_disk.json
@@ -23,7 +23,7 @@
     ],
     "P": [
       {
-        "item": "rebornstorage:small_item_disk_part"
+        "tag": "refinedstorage:parts/items/256k"
       }
     ]
   },

--- a/src/main/resources/data/rebornstorage/recipes/parts/large_fluid_disk_part.json
+++ b/src/main/resources/data/rebornstorage/recipes/parts/large_fluid_disk_part.json
@@ -8,7 +8,7 @@
   "key": {
     "G": [
       {
-        "item": "rebornstorage:medium_fluid_disk_part"
+        "tag": "refinedstorage:parts/fluids/1024k"
       }
     ],
     "D": [

--- a/src/main/resources/data/rebornstorage/recipes/parts/large_item_disk_part.json
+++ b/src/main/resources/data/rebornstorage/recipes/parts/large_item_disk_part.json
@@ -8,7 +8,7 @@
   "key": {
     "G": [
       {
-        "item": "rebornstorage:medium_item_disk_part"
+        "tag": "refinedstorage:parts/items/1024k"
       }
     ],
     "D": [

--- a/src/main/resources/data/rebornstorage/recipes/parts/larger_fluid_disk_part.json
+++ b/src/main/resources/data/rebornstorage/recipes/parts/larger_fluid_disk_part.json
@@ -8,7 +8,7 @@
   "key": {
     "G": [
       {
-        "item": "rebornstorage:large_fluid_disk_part"
+        "tag": "refinedstorage:parts/fluids/4096k"
       }
     ],
     "D": [

--- a/src/main/resources/data/rebornstorage/recipes/parts/larger_item_disk_part.json
+++ b/src/main/resources/data/rebornstorage/recipes/parts/larger_item_disk_part.json
@@ -8,7 +8,7 @@
   "key": {
     "G": [
       {
-        "item": "rebornstorage:large_item_disk_part"
+        "tag": "refinedstorage:parts/items/4096k"
       }
     ],
     "D": [

--- a/src/main/resources/data/rebornstorage/recipes/parts/medium_fluid_disk_part.json
+++ b/src/main/resources/data/rebornstorage/recipes/parts/medium_fluid_disk_part.json
@@ -8,7 +8,7 @@
   "key": {
     "G": [
       {
-        "item": "rebornstorage:small_fluid_disk_part"
+        "tag": "refinedstorage:parts/fluids/256k"
       }
     ],
     "D": [

--- a/src/main/resources/data/rebornstorage/recipes/parts/medium_item_disk_part.json
+++ b/src/main/resources/data/rebornstorage/recipes/parts/medium_item_disk_part.json
@@ -8,7 +8,7 @@
   "key": {
     "G": [
       {
-        "item": "rebornstorage:small_item_disk_part"
+        "tag": "refinedstorage:parts/items/256k"
       }
     ],
     "D": [

--- a/src/main/resources/data/refinedstorage/tags/items/disks.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#refinedstorage:disks/items",
+    "#refinedstorage:disks/fluids"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/fluids.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/fluids.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#refinedstorage:disks/fluids/16384k"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/fluids/1024k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/fluids/1024k.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "refinedstorage:1024k_fluid_storage_disk",
+    "rebornstorage:medium_fluid_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/fluids/16384k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/fluids/16384k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:larger_fluid_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/fluids/256k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/fluids/256k.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "refinedstorage:256k_fluid_storage_disk",
+    "rebornstorage:small_fluid_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/fluids/4096k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/fluids/4096k.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "refinedstorage:4096k_fluid_storage_disk",
+    "rebornstorage:large_fluid_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/items.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/items.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "#refinedstorage:disks/items/256k",
+    "#refinedstorage:disks/items/1024k",
+    "#refinedstorage:disks/items/4096k",
+    "#refinedstorage:disks/items/16384k"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/items/1024k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/items/1024k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:medium_item_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/items/16384k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/items/16384k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:larger_item_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/items/256k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/items/256k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:small_item_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/disks/items/4096k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/disks/items/4096k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:large_item_disk"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#refinedstorage:parts/items",
+    "#refinedstorage:parts/fluids"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/fluids.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/fluids.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#refinedstorage:parts/fluids/16384k"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/fluids/1024k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/fluids/1024k.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "refinedstorage:1024k_fluid_storage_part",
+    "rebornstorage:medium_fluid_disk_part"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/fluids/16384k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/fluids/16384k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:larger_fluid_disk_part"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/fluids/256k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/fluids/256k.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "refinedstorage:256k_fluid_storage_part",
+    "rebornstorage:small_fluid_disk_part"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/fluids/4096k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/fluids/4096k.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "refinedstorage:4096k_fluid_storage_part",
+    "rebornstorage:large_fluid_disk_part"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/items.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/items.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "#refinedstorage:parts/items/256k",
+    "#refinedstorage:parts/items/1024k",
+    "#refinedstorage:parts/items/4096k",
+    "#refinedstorage:parts/items/16384k"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/items/1024k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/items/1024k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:medium_item_disk_part"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/items/16384k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/items/16384k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:larger_item_disk_part"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/items/256k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/items/256k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:small_item_disk_part"
+  ]
+}

--- a/src/main/resources/data/refinedstorage/tags/items/parts/items/4096k.json
+++ b/src/main/resources/data/refinedstorage/tags/items/parts/items/4096k.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "rebornstorage:large_item_disk_part"
+  ]
+}


### PR DESCRIPTION
This is added to have compat with other mods which add higher tier disks and parts, such as [Extra Disks](https://github.com/MelanX/ExtraDisks) or [ExtraStorage](https://github.com/Edivad99/ExtraStorage). 
This way, your items can be used to craft the ones of the other mods because they also use these tags in crafting recipes. This will allow using your mod in a modpack and the other mods without conflicting recipes. 