### PR TITLE
Fix MultiCrafter page desync

### DIFF
--- a/src/main/java/net/gigabit101/rebornstorage/blocks/BlockMultiCrafter.java
+++ b/src/main/java/net/gigabit101/rebornstorage/blocks/BlockMultiCrafter.java
@@ -149,7 +149,7 @@ public class BlockMultiCrafter extends BaseEntityBlock
             } else
             {
                 if(level.isClientSide)
-                    PacketHandler.sendToServer(new PacketGui(1, blockPos));
+                    PacketHandler.sendToServer(new PacketGui(0, blockPos));
                 return InteractionResult.SUCCESS;
             }
             return InteractionResult.SUCCESS;


### PR DESCRIPTION
There is probably a prettier way to fix the issue, but page being initially set to 0 fixes it. This is because it prevents from entering into [this if](https://github.com/TechReborn/RebornStorage/blob/1.18.2/src/main/java/net/gigabit101/rebornstorage/packet/PacketGui.java#L50).

Before fix: When re-opening the GUI after closing it on page > 1, it displayed the first page content while displaying the wrong page number. To prevent the issue from happening, we had to exit the GUI on the first page. To fix the issue in-game, we had to change page twice (go to prev/next page, then go back)

After fix: Works as expected, when opening the GUI for the first time, it displays the first page content, with "page 1 of x". When opening it after closing on another page, it opens the right page content (the one opened during last exit) with the right page number.